### PR TITLE
Update to html2pug@4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Settings object with defaults.
 ```json
     {
       "html2pug": {
-        "useTabs": false, // !editor.options.insertSpaces
-        "isFragment": true,
-        // "useDoubleQuotes": false, //waiting html2pug version
-        "useCommas": false,
+        "tabs": false, // !editor.options.insertSpaces
+        "fragment": true,
+        "doubleQuotes": false,
+        "commas": false,
       }
     }
 ```

--- a/commands/transformHtml.js
+++ b/commands/transformHtml.js
@@ -16,10 +16,10 @@ function transformSelections(editor) {
 	let selections = editor.selections;
 	const vscodeConfig = vscode.workspace.getConfiguration('html2pug', vscode.window.activeTextEditor.document.uri);
 	const config = {
-		useTabs: vscodeConfig.get('useTabs', !editor.options.insertSpaces),
-		isFragment: vscodeConfig.get('isFragment', true),
-		useDoubleQuotes: vscodeConfig.get('useDoubleQuotes', false),
-		useCommas: vscodeConfig.get('useCommas', false)
+		tabs: vscodeConfig.get('tabs', !editor.options.insertSpaces),
+		fragment: vscodeConfig.get('fragment', true),
+		doubleQuotes: vscodeConfig.get('doubleQuotes', false),
+		commas: vscodeConfig.get('commas', false)
 	};
 
 	return selections.map((selection) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,11 +75,6 @@
             "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
             "dev": true
         },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -189,11 +184,6 @@
                 "upper-case": "^1.1.1"
             }
         },
-        "camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -240,49 +230,6 @@
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
             "dev": true
         },
-        "cliui": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-            "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-            },
-            "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
-            }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -325,16 +272,6 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
-        "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -360,11 +297,6 @@
                     "dev": true
                 }
             }
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "deep-is": {
             "version": "0.1.3",
@@ -408,14 +340,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
-        },
-        "error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "requires": {
-                "is-arrayish": "^0.2.1"
-            }
         },
         "es6-promise": {
             "version": "4.2.6",
@@ -581,20 +505,6 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
-        "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-            "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            }
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -654,14 +564,6 @@
                 "flat-cache": "^2.0.1"
             }
         },
-        "find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-            "requires": {
-                "locate-path": "^2.0.0"
-            }
-        },
         "flat-cache": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -708,20 +610,10 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "get-caller-file": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-        },
         "get-stdin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
             "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
-        },
-        "get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "getpass": {
             "version": "0.1.7",
@@ -751,11 +643,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
-        },
-        "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "growl": {
             "version": "1.10.3",
@@ -791,11 +678,6 @@
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
-        "hosted-git-info": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
-        },
         "html-minifier": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
@@ -823,14 +705,21 @@
             }
         },
         "html2pug": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/html2pug/-/html2pug-3.0.0.tgz",
-            "integrity": "sha512-viBTcX8/m29BYbcaytkMwtAhKf6Essal+URXetyN+5xkhMR2K4DYyW14ovEKu34bAC7/v3laRsmE2EFY82rVJA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html2pug/-/html2pug-4.0.0.tgz",
+            "integrity": "sha512-CeOvSspLyo6F/hKflOF1W1XjgvQ1FJkl6hM9SjUFBDe9o2+HG7V+F2HtRGDwxvJvn/bH7M0namSWpsBVj5vzLQ==",
             "requires": {
                 "get-stdin": "^6.0.0",
+                "has-flag": "^4.0.0",
                 "html-minifier": "^4.0.0",
-                "parse5": "^5.1.0",
-                "yargs": "^8.0.2"
+                "parse5": "^5.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                }
             }
         },
         "http-proxy-agent": {
@@ -949,31 +838,17 @@
                 }
             }
         },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
         },
         "is-promise": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -984,7 +859,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
@@ -1050,14 +926,6 @@
                 "verror": "1.10.0"
             }
         },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "requires": {
-                "invert-kv": "^1.0.0"
-            }
-        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1066,26 +934,6 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
-            }
-        },
-        "load-json-file": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
-            }
-        },
-        "locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-            "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -1098,23 +946,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
             "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
-        },
-        "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-            "requires": {
-                "mimic-fn": "^1.0.0"
-            }
         },
         "mime-db": {
             "version": "1.40.0",
@@ -1134,7 +965,8 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -1241,30 +1073,6 @@
                 "lower-case": "^1.1.1"
             }
         },
-        "normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "^2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1303,47 +1111,11 @@
                 "wordwrap": "~1.0.0"
             }
         },
-        "os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-            "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-            }
-        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
-        "p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "requires": {
-                "p-try": "^1.0.0"
-            }
-        },
-        "p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-            "requires": {
-                "p-limit": "^1.1.0"
-            }
-        },
-        "p-try": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "param-case": {
             "version": "2.1.1",
@@ -1362,23 +1134,10 @@
                 "callsites": "^3.0.0"
             }
         },
-        "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "requires": {
-                "error-ex": "^1.2.0"
-            }
-        },
         "parse5": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
             "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-        },
-        "path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -1395,31 +1154,14 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-        },
-        "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-        },
-        "path-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-            "requires": {
-                "pify": "^2.0.0"
-            }
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
-        },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "prelude-ls": {
             "version": "1.1.2",
@@ -1432,11 +1174,6 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
             "version": "1.1.31",
@@ -1461,25 +1198,6 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
             "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
             "dev": true
-        },
-        "read-pkg": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-            "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-            "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
-            }
         },
         "regexpp": {
             "version": "2.0.1",
@@ -1520,29 +1238,11 @@
                 "uuid": "^3.3.2"
             }
         },
-        "require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-        },
-        "require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
-        },
-        "resolve": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-            "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
-            "requires": {
-                "path-parse": "^1.0.6"
-            }
         },
         "resolve-from": {
             "version": "4.0.0",
@@ -1602,17 +1302,14 @@
         "semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
         },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -1620,12 +1317,14 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -1652,34 +1351,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "spdx-correct": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-            "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -1708,6 +1379,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
             "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -1717,6 +1389,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^3.0.0"
             },
@@ -1724,19 +1397,10 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 }
             }
-        },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
             "version": "2.0.1",
@@ -1869,9 +1533,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.5.10",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-            "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+            "version": "3.5.12",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+            "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
             "requires": {
                 "commander": "~2.20.0",
                 "source-map": "~0.6.1"
@@ -1914,15 +1578,6 @@
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
-        "validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -1963,57 +1618,16 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
-        },
-        "which-module": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
-        },
-        "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-            "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-            },
-            "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
-            }
         },
         "wrappy": {
             "version": "1.0.2",
@@ -2028,44 +1642,6 @@
             "dev": true,
             "requires": {
                 "mkdirp": "^0.5.1"
-            }
-        },
-        "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
-        "yargs": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-            "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-            "requires": {
-                "camelcase": "^4.1.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "read-pkg-up": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^7.0.0"
-            }
-        },
-        "yargs-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-            "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-            "requires": {
-                "camelcase": "^4.1.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
         "vscode": "^1.1.34"
     },
     "dependencies": {
-        "html2pug": "^3.0.0"
+        "html2pug": "^4.0.0"
     }
 }


### PR DESCRIPTION
The latest version of `html2pug` introduced an option to set the quote style to double quotes, and some breaking changes due to reverting of option key names to better match the command line API.

This PR updates the `html2pug` dependency to `4.0.0` and recreates the option object.

Closes #4 